### PR TITLE
Add a callback to the main `success` function

### DIFF
--- a/ajaxify.js
+++ b/ajaxify.js
@@ -26,6 +26,7 @@ ajaxify = function(settings) {
   var ajaxinateLink = settings.ajaxinateLink || '.page a' // Class Selector for ajax pagination links
   var fade = settings.fade || 'fast' // fade speed
   var textChange = settings.textChange || 'Loading' // Text whilst loading content
+  const callback = settings.callback || false
 
   var linkElem;
   var contentContainer;
@@ -41,6 +42,8 @@ ajaxify = function(settings) {
         dataType: 'html',
         url: moreURL,
         success: function(data) {
+          if(callback)
+            callback(data)
           if (pageType == 'ajax') {
             $(ajaxinateContainer).not('[data-page="'+pageNumber+'"]').hide();
             history.pushState({}, pageNumber, moreURL);

--- a/ajaxify.js
+++ b/ajaxify.js
@@ -42,8 +42,6 @@ ajaxify = function(settings) {
         dataType: 'html',
         url: moreURL,
         success: function(data) {
-          if(callback)
-            callback(data)
           if (pageType == 'ajax') {
             $(ajaxinateContainer).not('[data-page="'+pageNumber+'"]').hide();
             history.pushState({}, pageNumber, moreURL);
@@ -58,6 +56,10 @@ ajaxify = function(settings) {
             $.ajaxinationClick();
           } else if (pageType == 'endlessClick') {
             $.endlessClick();
+          }
+          $(document).trigger('ajaxify:updated', [data]);
+          if(callback && typeof(callback) === 'function') {
+            callback(data);
           }
         }
       });


### PR DESCRIPTION
Allow users to set a callback to be fired every time Ajaxify sucessfully fetches some data.